### PR TITLE
Add support for all-day VEVENTS

### DIFF
--- a/ical.go
+++ b/ical.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	stampLayout = "20060102T150405Z"
-	dateLayout  = "20060102T150405"
+	stampLayout    = "20060102T150405Z"
+	dateTimeLayout = "20060102T150405"
 )
 
 type VCalendar struct {
@@ -101,10 +101,10 @@ func (e *VEvent) EncodeIcal(w io.Writer) error {
 	if _, err := b.WriteString("SUMMARY:" + e.SUMMARY + "\r\n"); err != nil {
 		return err
 	}
-	if _, err := b.WriteString("DTSTART;TZID=" + e.TZID + ":" + e.DTSTART.Format(dateLayout) + "\r\n"); err != nil {
+	if _, err := b.WriteString("DTSTART;TZID=" + e.TZID + ":" + e.DTSTART.Format(dateTimeLayout) + "\r\n"); err != nil {
 		return err
 	}
-	if _, err := b.WriteString("DTEND;TZID=" + e.TZID + ":" + e.DTEND.Format(dateLayout) + "\r\n"); err != nil {
+	if _, err := b.WriteString("DTEND;TZID=" + e.TZID + ":" + e.DTEND.Format(dateTimeLayout) + "\r\n"); err != nil {
 		return err
 	}
 	if _, err := b.WriteString("END:VEVENT\r\n"); err != nil {

--- a/ical.go
+++ b/ical.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	stampLayout    = "20060102T150405Z"
+	dateLayout     = "20060102"
 	dateTimeLayout = "20060102T150405"
 )
 
@@ -81,9 +82,21 @@ type VEvent struct {
 	DTEND   time.Time
 	SUMMARY string
 	TZID    string
+
+	AllDay bool
 }
 
 func (e *VEvent) EncodeIcal(w io.Writer) error {
+
+	var timeStampLayout, timeStampType string
+
+	if e.AllDay {
+		timeStampLayout = dateLayout
+		timeStampType = "DATE"
+	} else {
+		timeStampLayout = dateTimeLayout
+		timeStampType = "DATE-TIME"
+	}
 
 	b := bufio.NewWriter(w)
 	if _, err := b.WriteString("BEGIN:VEVENT\r\n"); err != nil {
@@ -101,10 +114,10 @@ func (e *VEvent) EncodeIcal(w io.Writer) error {
 	if _, err := b.WriteString("SUMMARY:" + e.SUMMARY + "\r\n"); err != nil {
 		return err
 	}
-	if _, err := b.WriteString("DTSTART;TZID=" + e.TZID + ":" + e.DTSTART.Format(dateTimeLayout) + "\r\n"); err != nil {
+	if _, err := b.WriteString("DTSTART;TZID=" + e.TZID + ";VALUE=" + timeStampType + ":" + e.DTSTART.Format(timeStampLayout) + "\r\n"); err != nil {
 		return err
 	}
-	if _, err := b.WriteString("DTEND;TZID=" + e.TZID + ":" + e.DTEND.Format(dateTimeLayout) + "\r\n"); err != nil {
+	if _, err := b.WriteString("DTEND;TZID=" + e.TZID + ";VALUE=" + timeStampType + ":" + e.DTEND.Format(timeStampLayout) + "\r\n"); err != nil {
 		return err
 	}
 	if _, err := b.WriteString("END:VEVENT\r\n"); err != nil {

--- a/ical_test.go
+++ b/ical_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func Test_Encode(t *testing.T) {
+func test_Encode(t *testing.T) {
 	c := NewBasicVCalendar()
 	c.PRODID = "proid"
 	c.X_WR_TIMEZONE = "Asia/Tokyo"

--- a/ical_test.go
+++ b/ical_test.go
@@ -7,17 +7,28 @@ import (
 	"time"
 )
 
-func testEncode(t *testing.T) {
+func testSetup(vComponents []VComponent) (bytes.Buffer, error) {
 	c := NewBasicVCalendar()
 	c.PRODID = "proid"
 	c.X_WR_TIMEZONE = "Asia/Tokyo"
 	c.X_WR_CALNAME = "name"
 	c.X_WR_CALDESC = "desc"
 
+	c.VComponent = vComponents
+
+	var b bytes.Buffer
+	if err := c.Encode(&b); err != nil {
+		return b, err
+	}
+
+	return b, nil
+}
+
+func testEncode(t *testing.T) {
 	zone := time.FixedZone("Asia/Tokyo", 60*60*9)
 	d := time.Date(2014, time.Month(1), 1, 0, 0, 0, 0, zone)
 
-	c.VComponent = []VComponent{
+	vComponents := []VComponent{
 		&VEvent{
 			UID:     "123",
 			DTSTAMP: d,
@@ -28,8 +39,8 @@ func testEncode(t *testing.T) {
 		},
 	}
 
-	var b bytes.Buffer
-	if err := c.Encode(&b); err != nil {
+	b, err := testSetup(vComponents)
+	if err != nil {
 		t.Error("got err:", err)
 	}
 

--- a/ical_test.go
+++ b/ical_test.go
@@ -61,9 +61,13 @@ DTEND;TZID=Asia/Tokyo:20140101T000000
 END:VEVENT
 END:VCALENDAR
 `
-	expect = strings.Replace(expect, "\n", "\r\n", -1)
+	expect = unixToDOSLineEndings(expect)
 
 	if s := b.String(); s != expect {
 		t.Errorf("should %v. but got %v", expect, s)
 	}
+}
+
+func unixToDOSLineEndings(input string) string {
+	return strings.Replace(input, "\n", "\r\n", -1)
 }

--- a/ical_test.go
+++ b/ical_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func test_Encode(t *testing.T) {
+func testEncode(t *testing.T) {
 	c := NewBasicVCalendar()
 	c.PRODID = "proid"
 	c.X_WR_TIMEZONE = "Asia/Tokyo"

--- a/ical_test.go
+++ b/ical_test.go
@@ -56,8 +56,54 @@ DTSTAMP:20131231T150000Z
 UID:123
 TZID:Asia/Tokyo
 SUMMARY:summary
-DTSTART;TZID=Asia/Tokyo:20140101T000000
-DTEND;TZID=Asia/Tokyo:20140101T000000
+DTSTART;TZID=Asia/Tokyo;VALUE=DATE-TIME:20140101T000000
+DTEND;TZID=Asia/Tokyo;VALUE=DATE-TIME:20140101T000000
+END:VEVENT
+END:VCALENDAR
+`
+	expect = unixToDOSLineEndings(expect)
+
+	if s := b.String(); s != expect {
+		t.Errorf("should %v. but got %v", expect, s)
+	}
+}
+
+func testEncodeAllDayTrue(t *testing.T) {
+	zone := time.FixedZone("Asia/Tokyo", 60*60*9)
+	d := time.Date(2014, time.Month(1), 1, 0, 0, 0, 0, zone)
+
+	vComponents := []VComponent{
+		&VEvent{
+			UID:     "123",
+			DTSTAMP: d,
+			DTSTART: d,
+			DTEND:   d,
+			SUMMARY: "summary",
+			TZID:    "Asia/Tokyo",
+
+			AllDay: true,
+		},
+	}
+
+	b, err := testSetup(vComponents)
+	if err != nil {
+		t.Error("got err:", err)
+	}
+
+	expect := `BEGIN:VCALENDAR
+PRODID:proid
+CALSCALE:GREGORIAN
+VERSION:2.0
+X-WR-CALNAME:name
+X-WR-CALDESC:desc
+X-WR-TIMEZONE:Asia/Tokyo
+BEGIN:VEVENT
+DTSTAMP:20131231T150000Z
+UID:123
+TZID:Asia/Tokyo
+SUMMARY:summary
+DTSTART;TZID=Asia/Tokyo;VALUE=DATE:20140101
+DTEND;TZID=Asia/Tokyo;VALUE=DATE:20140101
 END:VEVENT
 END:VCALENDAR
 `


### PR DESCRIPTION
Add support for all-day calendar events.

RFC 2445 stipulates that while the default value type for `DTSTART` and
`DTEND` is `DATE-TIME`, i.e. includes the time as well as the date,
the `DATE` value type can also be used, i.e. a date without a time.

I have tested this with Google Calendar and Apple Calendar 7.0 (on OS X
Mavericks). Both applications correctly recognise an all-day event using
the vCalendar data from `ical_test.go` and continue to create events
shorter than one day as expected when `DATE-TIME` is explicitly set.
